### PR TITLE
Add `keypathClass` macro that can be used without any instance of given class

### DIFF
--- a/extobjc/EXTKeyPathCoding.h
+++ b/extobjc/EXTKeyPathCoding.h
@@ -37,3 +37,6 @@ NSString *versionPath = @keypath(NSObject.class, version);
 
 #define keypath2(OBJ, PATH) \
     (((void)(NO && ((void)OBJ.PATH, NO)), # PATH))
+
+#define keypathClass(CLASS, PATH) \
+    keypath2(((CLASS *)[[CLASS alloc] init]), PATH)


### PR DESCRIPTION
This macro allows you to specify key-path by using the class and no single instance is needed.
It allocates new instance and then uses `keypath2` macro. The allocation code during compilation so no object is really created in runtime.
Useful for example in `+keyPathsForValuesAffecting<Something>`.
