### PR TITLE
Add @keypathClassInstance()

### DIFF
--- a/Tests/EXTKeyPathCodingTest.m
+++ b/Tests/EXTKeyPathCodingTest.m
@@ -46,6 +46,20 @@
     STAssertEqualObjects(path, @"description", @"");
 }
 
+- (void)testClassInstanceKeyPath {
+    NSString *path = @keypathClassInstance(NSString, hash);
+    STAssertEqualObjects(path, @"hash", @"");
+    
+    path = @keypathClassInstance(NSError, domain, hash);
+    STAssertEqualObjects(path, @"hash", @"");
+    
+    path = @keypathClassInstance(NSError, domain.hash);
+    STAssertEqualObjects(path, @"domain.hash", @"");
+    
+    path = @keypathClassInstance(MyClass, someUniqueProperty);
+    STAssertEqualObjects(path, @"someUniqueProperty", @"");
+}
+
 - (void)testMyClassInstanceKeyPath {
     NSString *path = @keypath(MyClass.new, someUniqueProperty);
     STAssertEqualObjects(path, @"someUniqueProperty", @"");

--- a/extobjc/EXTKeyPathCoding.h
+++ b/extobjc/EXTKeyPathCoding.h
@@ -43,3 +43,26 @@ NSString *lowercaseStringPath = @keypath(NSString.new, lowercaseString);
 
 #define keypath2(OBJ, PATH) \
     (((void)(NO && ((void)OBJ.PATH, NO)), # PATH))
+
+/**
+ * \@keypathClassInstance allows compile-time verification of key paths. Similar to
+ * \@keypath, but accept a class as parameter instead of a instance variable.
+ * @code
+
+NSString *objectIDPath = @keypathClassInstance(NSManagedObject, objectID);
+// => @"objectID"
+
+NSString *footerViewFramePath = @keypathClassInstance(UITableView, tableFooterView, frame);
+// => @"frame"
+ 
+ * @endcode
+ */
+
+#define keypathClassInstance(...)\
+    metamacro_if_eq(2, metamacro_argcount(__VA_ARGS__))(keypathClassInstance1(__VA_ARGS__))(keypathClassInstance2(__VA_ARGS__))
+
+#define keypathClassInstance1(CLASS, PATH)\
+    (({CLASS *_proxy_; ((void)(NO && ((void)_proxy_.PATH, NO)), # PATH);}))
+
+#define keypathClassInstance2(CLASS, PROPERTY, PATH)\
+    (({CLASS *_proxy_; ((void)(NO && ((void)_proxy_.PROPERTY.PATH, NO)), # PATH);}))


### PR DESCRIPTION
We use @keypath a lot in our project, sometime we write code like this:

``` Objective-C
Channel *obj = nil;
NSFetchRequest *request = [NSFetchRequest fetchRequestWithEntityName:@"Channel"];
request.predicate = [NSPredicate predicateWithFormat:@"%K = %@", @keypath(obj, code), code];
```

The pain point was we must define a instance before to let @keypath generate a instance keypath.

So I made @keypathClassInstance to solve that. Now we can write like this:

``` Objective-C
NSFetchRequest *request = [NSFetchRequest fetchRequestWithEntityName:@"Channel"];
request.predicate = [NSPredicate predicateWithFormat:@"%K = %@", @keypathClassInstance(Channel, code), code];
```

You may edit the document, as English not my native.
