### PR TITLE
Test for early execution of @onExit blocks

### DIFF
--- a/Tests/EXTScopeTest.m
+++ b/Tests/EXTScopeTest.m
@@ -68,6 +68,15 @@
     }
 
     STAssertEquals(executed, 2U, @"onExit blocks should be executed even when goto is used");
+    
+    str = [@"foo" mutableCopy];
+    {
+        @onExit {
+            [str appendString:@"baz"];
+        };
+        [str appendString:@"bar"];
+        STAssertEqualObjects(str, @"foobar", @"onExit block should not be executed before the scope ends");
+    }
 
     str = [@"foo" mutableCopy];
     [self nestedAppend:str];


### PR DESCRIPTION
Had a look at the test suite and noticed this wasn't explicitly tested, so I added a little something.
