### PR TITLE
Added guard against strongifying garbage references to @strongify.

### DIFF
--- a/extobjc/EXTScope.h
+++ b/extobjc/EXTScope.h
@@ -91,9 +91,13 @@
 typedef void (^ext_cleanupBlock_t)();
 
 void ext_executeCleanupBlock (__strong ext_cleanupBlock_t *block);
+void ext_addGarbageGuard (__strong NSObject *target);
+void ext_checkGarbageGuard (__unsafe_unretained NSObject *target);
 
 #define ext_weakify_(INDEX, CONTEXT, VAR) \
+    ext_addGarbageGuard(VAR);\
     CONTEXT __typeof__(VAR) metamacro_concat(VAR, _weak_) = (VAR);
 
 #define ext_strongify_(INDEX, VAR) \
+    ext_checkGarbageGuard(metamacro_concat(VAR, _weak_));\
     __strong __typeof__(VAR) VAR = metamacro_concat(VAR, _weak_);

--- a/extobjc/EXTScope.m
+++ b/extobjc/EXTScope.m
@@ -8,8 +8,67 @@
 //
 
 #import "EXTScope.h"
+#import <libkern/OSAtomic.h>
+#import <objc/runtime.h>
+
+static NSMutableSet *swizzledClasses() {
+    static dispatch_once_t onceToken;
+    static NSMutableSet *swizzledClasses = nil;
+    dispatch_once(&onceToken, ^{
+        swizzledClasses = [[NSMutableSet alloc] init];
+    });
+    
+    return swizzledClasses;
+}
+
+static OSSpinLock garbageReferencesLock;
+static CFMutableSetRef garbageReferences() {
+    static dispatch_once_t onceToken;
+    static CFMutableSetRef garbageReferences = NULL;
+    dispatch_once(&onceToken, ^{
+        garbageReferences = CFSetCreateMutable(NULL, 0, NULL);
+    });
+    return garbageReferences;
+}
 
 void ext_executeCleanupBlock (__strong ext_cleanupBlock_t *block) {
     (*block)();
 }
 
+void ext_addGarbageGuard (__strong NSObject *target) {
+    void (^swizzle)(Class) = ^(Class classToSwizzle){
+        NSString *className = NSStringFromClass(classToSwizzle);
+        if ([swizzledClasses() containsObject:className]) return;
+        
+        SEL deallocSelector = sel_registerName("dealloc");
+        
+        Method deallocMethod = class_getInstanceMethod(classToSwizzle, deallocSelector);
+        void (*originalDealloc)(id, SEL) = (__typeof__(originalDealloc))method_getImplementation(deallocMethod);
+        
+        id newDealloc = ^(__unsafe_unretained NSObject *self) {
+            OSSpinLockLock(&garbageReferencesLock);
+            CFSetAddValue(garbageReferences(), (__bridge const void *)(self));
+            OSSpinLockUnlock(&garbageReferencesLock);
+            originalDealloc(self, deallocSelector);
+            OSSpinLockLock(&garbageReferencesLock);
+            CFSetRemoveValue(garbageReferences(), (__bridge const void *)(self));
+            OSSpinLockUnlock(&garbageReferencesLock);
+        };
+        
+        class_replaceMethod(classToSwizzle, deallocSelector, imp_implementationWithBlock(newDealloc), method_getTypeEncoding(deallocMethod));
+        
+        [swizzledClasses() addObject:className];
+    };
+    
+    @synchronized (swizzledClasses()) {
+        swizzle(target.class);
+    }
+}
+
+void ext_checkGarbageGuard (__unsafe_unretained NSObject *target) {
+    Boolean targetIsGarbage = false;
+    OSSpinLockLock(&garbageReferencesLock);
+    targetIsGarbage = CFSetContainsValue(garbageReferences(), (__bridge const void *)(target));
+    OSSpinLockUnlock(&garbageReferencesLock);
+    if (targetIsGarbage) [NSException raise:NSInternalInconsistencyException format:@"Attempted to strongify garbage reference."];
+}


### PR DESCRIPTION
:warning: **NOT READY TO MERGE** :warning: 

Prompted by ReactiveCocoa/ReactiveCocoa#463.

This adds a check to `@strongify` that prevents it from referencing objects that are deallocating.
