### PR TITLE
keypaths working across to-many relationships

### DIFF
--- a/extobjc/EXTKeyPathCoding.h
+++ b/extobjc/EXTKeyPathCoding.h
@@ -44,28 +44,25 @@ NSString *lowercaseStringPath = @keypath(NSString.new, lowercaseString);
 #define keypath2(OBJ, PATH) \
     (((void)(NO && ((void)OBJ.PATH, NO)), # PATH))
 
+/**
+ * \@collectionKeypath allows compile-time verification of key paths across collections NSArray/NSSet etc. Given a real object
+ * receiver, collection object receiver and related keypaths:
+ *
+ * @code
+ 
+ NSString *employessFirstNamePath = @collectionKeypath(department.employees, Employee.new, firstName)
+ // => @"employees.firstName"
+ 
+ NSString *employessFirstNamePath = @collectionKeypath(Department.new, employees, Employee.new, firstName)
+ // => @"employees.firstName"
 
+ * @endcode
+ *
+ */
 #define collectionKeypath(...) \
     metamacro_if_eq(3, metamacro_argcount(__VA_ARGS__))(collectionKeypath3(__VA_ARGS__))(collectionKeypath4(__VA_ARGS__))
 
-#define collectionKeypath3(PATH, COLLECTION_OBJECT, COLLECTION_PATH) ([[NSString stringWithFormat:@"%s.%s",keypath(PATH), keypath2(COLLECTION_OBJECT, COLLECTION_PATH)] UTF8String])
+#define collectionKeypath3(PATH, COLLECTION_OBJECT, COLLECTION_PATH) ([[NSString stringWithFormat:@"%s.%s",keypath(PATH), keypath(COLLECTION_OBJECT, COLLECTION_PATH)] UTF8String])
 
-#define collectionKeypath4(OBJ, PATH, COLLECTION_OBJECT, COLLECTION_PATH) ([[NSString stringWithFormat:@"%s.%s",keypath2(OBJ, PATH), keypath2(COLLECTION_OBJECT, COLLECTION_PATH)] UTF8String])
+#define collectionKeypath4(OBJ, PATH, COLLECTION_OBJECT, COLLECTION_PATH) ([[NSString stringWithFormat:@"%s.%s",keypath(OBJ, PATH), keypath(COLLECTION_OBJECT, COLLECTION_PATH)] UTF8String])
 
-
-#define avg(...)    collectionOperatorFromKeyValueOperator(NSAverageKeyValueOperator, __VA_ARGS__)
-#define count(...)  collectionOperatorFromKeyValueOperator(NSCountKeyValueOperator, __VA_ARGS__)
-#define max(...)    collectionOperatorFromKeyValueOperator(NSMaximumKeyValueOperator, __VA_ARGS__)
-#define min(...)    collectionOperatorFromKeyValueOperator(NSMinimumKeyValueOperator, __VA_ARGS__)
-#define sum(...)    collectionOperatorFromKeyValueOperator(NSSumKeyValueOperator, __VA_ARGS__)
-
-#define distinctUnionOfArray(...) collectionOperatorFromKeyValueOperator(NSDistinctUnionOfArraysKeyValueOperator, __VA_ARGS__)
-#define distinctUnionOfObjects(...) collectionOperatorFromKeyValueOperator(NSDistinctUnionOfObjectsKeyValueOperator, __VA_ARGS__)
-#define distinctUnionOfSets(...) collectionOperatorFromKeyValueOperator(NSDistinctUnionOfSetsKeyValueOperator, __VA_ARGS__)
-
-#define unionOfArrays(...) collectionOperatorFromKeyValueOperator(NSUnionOfArraysKeyValueOperator, __VA_ARGS__)
-#define unionOfObjects(...) collectionOperatorFromKeyValueOperator(NSUnionOfObjectsKeyValueOperator, __VA_ARGS__)
-#define unionOfSets(...) collectionOperatorFromKeyValueOperator(NSUnionOfSetsKeyValueOperator, __VA_ARGS__)
-
-#define collectionOperatorFromKeyValueOperator(KeyValueOperator, ...) \
-([[NSString stringWithFormat:@"@%@.%@", KeyValueOperator, @keypath(__VA_ARGS__)] UTF8String])


### PR DESCRIPTION
NSPredicate *predicate = [NSPredicate predicateWithFormat:
    @"ANY %K like 'Matthew'", relationship(department.employees, employee.firstName)];

NSPredicate *predicate = [NSPredicate predicateWithFormat:
    @"ANY %K like 'Matthew'", relationship(Department.new, employees, Employee.new, firstName)];

If you could convert to c so it works with @to-many or something that would be cool. :)
My c is non existent.
