### PR TITLE
EXTAspect: support getters & setters at the same time

### DIFF
--- a/extobjc/EXTAspect.m
+++ b/extobjc/EXTAspect.m
@@ -435,14 +435,16 @@ static void ext_injectAspect (Class containerClass, Class class) {
 
                     // hide this method from future searches
                     methodList[i] = NULL;
-                    break;
                 } else if (hasSettersAdvice && selector == attributes->setter) {
                     setter = method;
                     
                     // hide this method from future searches
                     methodList[i] = NULL;
-                    break;
                 }
+
+                // stop as soon as we have what we need
+                if ((getter || !hasGettersAdvice) && (setter || ! hasSettersAdvice))
+                    break;
             }
 
             if (getter || setter) {


### PR DESCRIPTION
Don't always break out of the "find getter and setter" loop as soon as one
of them is found; if there are advices for both, loop needs to keep
looking for the other one.

And a unit test for it.
