### PR TITLE
Replaced try/finally with autoreleasepool as a way to eat the @.

### DIFF
--- a/extobjc/EXTScope.h
+++ b/extobjc/EXTScope.h
@@ -29,7 +29,7 @@
  * a useless construct in such a case anyways.
  */
 #define onExit \
-    try {} @finally {} \
+    autoreleasepool {} \
     __strong ext_cleanupBlock_t metamacro_concat(ext_exitBlock_, __LINE__) __attribute__((cleanup(ext_executeCleanupBlock), unused)) = ^
 
 /**
@@ -43,7 +43,7 @@
  * See #strongify for an example of usage.
  */
 #define weakify(...) \
-    try {} @finally {} \
+    autoreleasepool {} \
     metamacro_foreach_cxt(ext_weakify_,, __weak, __VA_ARGS__)
 
 /**
@@ -51,7 +51,7 @@
  * classes that do not support weak references.
  */
 #define unsafeify(...) \
-    try {} @finally {} \
+    autoreleasepool {} \
     metamacro_foreach_cxt(ext_weakify_,, __unsafe_unretained, __VA_ARGS__)
 
 /**
@@ -81,7 +81,7 @@
  * @endcode
  */
 #define strongify(...) \
-    try {} @finally {} \
+    autoreleasepool {} \
     _Pragma("clang diagnostic push") \
     _Pragma("clang diagnostic ignored \"-Wshadow\"") \
     metamacro_foreach(ext_strongify_,, __VA_ARGS__) \


### PR DESCRIPTION
As reported in ReactiveCocoa/ReactiveCocoa#952 the presence of a `@try` block silences the warning about control reaching the end of a non-void block or function.

This PR replaces `@try` with `@autorelease` as a way to eat the @.

Both libextobjc's and RAC's tests pass with this change.
