### PR TITLE
EXTConcreteProtocol - improved inheritance support

### DIFF
--- a/Tests/EXTConcreteProtocolTest.h
+++ b/Tests/EXTConcreteProtocolTest.h
@@ -29,5 +29,6 @@
 - (void)testImplementations;
 - (void)testSimpleInheritance;
 - (void)testClassInheritanceWithProtocolInheritance;
+- (void)testInheritanceChain;
 
 @end

--- a/Tests/EXTConcreteProtocolTest.m
+++ b/Tests/EXTConcreteProtocolTest.m
@@ -95,6 +95,41 @@ static BOOL SubProtocolInitialized = NO;
 @implementation TestClass5
 @end
 
+// Classes for deeper test of preservation of inheritance
+@interface BaseA : NSObject
+@end
+@implementation BaseA
+- (int)callMeMaybe {return 1;}
+@end
+
+@protocol CallMeMaybeType <NSObject>
+@concrete
+- (int)callMeMaybe;
+@end
+@concreteprotocol(CallMeMaybeType)
+- (int)callMeMaybe {return 20;}
+@end
+
+@interface AOverride : BaseA <CallMeMaybeType>
+@end
+@implementation AOverride
+- (int)callMeMaybe {return 300;}
+@end
+
+@interface ASuper : BaseA <CallMeMaybeType>
+- (int)otherCallMe;
+@end
+@implementation ASuper
+- (int)otherCallMe {
+    return [super callMeMaybe];
+}
+@end
+
+@interface AConcrete : BaseA <CallMeMaybeType>
+@end
+@implementation AConcrete
+@end
+
 /*** logic test code ***/
 @implementation EXTConcreteProtocolTest
 - (void)tearDown {
@@ -148,6 +183,21 @@ static BOOL SubProtocolInitialized = NO;
     STAssertEqualObjects([obj getSomeString], @"SubProtocol", @"TestClass5 should be using SubProtocol implementation of getSomeString");
 
     STAssertEquals([TestClass5 meaningfulNumber], (NSUInteger)0, @"TestClass5 should not be using protocol implementation of meaningfulNumber");
+}
+
+- (void)testInheritanceChain
+{
+    AOverride *aOverride = [[AOverride alloc] init];
+    STAssertNotNil(aOverride, @"could not allocate concreteprotocol'd class");
+    STAssertEquals([aOverride callMeMaybe], (NSInteger)300, @"aOverride should not be using protocol implementation of callMeMaybe");
+    
+    ASuper *aSuper = [[ASuper alloc] init];
+    STAssertNotNil(aSuper, @"could not allocate concreteprotocol'd class");
+    STAssertEquals([aSuper otherCallMe], (NSInteger)1, @"aSuper should not be using protocol implementation of callMeMaybe, but should be using superclass definition.");
+    
+    AConcrete *aConcrete = [[AConcrete alloc] init];
+    STAssertNotNil(aConcrete, @"could not allocate concreteprotocol'd class");
+    STAssertEquals([aConcrete callMeMaybe], (NSInteger)20, @"aConcrete should not be using protocol implementation of callMeMaybe, but should be using superclass definition.");
 }
 
 @end

--- a/extobjc/EXTConcreteProtocol.m
+++ b/extobjc/EXTConcreteProtocol.m
@@ -33,9 +33,21 @@ static void ext_injectConcreteProtocol (Protocol *protocol, Class containerClass
         SEL selector = method_getName(method);
 
         // first, check to see if such an instance method already exists
-        // (on this class or on a superclass)
-        if (class_getInstanceMethod(class, selector)) {
-            // it does exist, so don't overwrite it
+        //   on the target class.
+        unsigned int methodCount = 0;
+        Method matchedMethod = NULL;
+        Method *methods = class_copyMethodList(class, &methodCount);
+        if(methods && (methodCount > 0)) {
+            for (unsigned int x = 0; x<methodCount; x++) {
+                Method targetClassMethod = methods[x];
+                if (selector == method_getName(targetClassMethod)) {
+                    matchedMethod = targetClassMethod;
+                    break;
+                }
+            }
+        }
+        if (matchedMethod) {
+            free(methods);
             continue;
         }
 


### PR DESCRIPTION
- Do not override a selector implemented on a conforming class. Similar to current behavior, but checks _only_ the target class, not it's super classes.
- Supports cases where a @concreteprotocol is used to encapsulate methods expected on subclasses (e.g. various methods called back onto a UIViewController) that their super classes may call if defined.
