### PR TITLE
[WIP] Compile time safe keypath

### DIFF
--- a/extobjc/EXTKeyPathCoding.h
+++ b/extobjc/EXTKeyPathCoding.h
@@ -42,7 +42,7 @@ NSString *lowercaseStringPath = @keypath(NSString.new, lowercaseString);
     (((void)(NO && ((void)PATH, NO)), strchr(# PATH, '.') + 1))
 
 #define keypath2(OBJ, PATH) \
-    "" ? @ # PATH : (__typeof__(^ NSString * { (void)((__typeof__(OBJ))nil).PATH; return nil; }())) nil
+    "" ? @ # PATH : (__typeof__(((__typeof__(OBJ))nil).PATH, @"")) nil
 
 /**
  * \@collectionKeypath allows compile-time verification of key paths across collections NSArray/NSSet etc. Given a real object


### PR DESCRIPTION
:warning: Not yet ready for merge due to problems with class keypaths, e.g. `@keypath(NSObject, version)`.

This allows it to be used to initialize static variables with the same type-safety and autocompletion benefits, at the cost of complicating the macro’s definition.

Note that this can only apply to the two-argument variant, since there is no way to split the string at compile-time.

Further, an additional change allows types to be passed as the first argument of `@keypath`, removing the need for workarounds like `@keypath(Foo.new, …)` which can be jarring, and which may be inconvenient in cases where e.g. `+new` is unavailable or you don’t even have a concrete class (e.g. with protocols). **However**, as @lldong [points out](https://github.com/jspahrsummers/libextobjc/pull/61#issuecomment-35913636), this currently breaks generation of class keypaths (e.g. `@keypath(NSObject, version)`).

~~The trick this uses to take the type of a comma express compiler-visible mechanism might be useful elsewhere; is something like that already available elsewhere?~~ I [ended up not requiring that trick](https://github.com/jspahrsummers/libextobjc/commit/68aa30ac72dead0a120d6de94e9cdae2acfee971) at all; using the comma operator simplified this greatly. Seems like only multistatement things would need the block trick, and they’re probably already in one.
- [ ] Can we pass classes directly for class key paths but also allow types?
