### PR TITLE
Scope macro keyword workaround

### DIFF
--- a/extobjc/EXTScope.h
+++ b/extobjc/EXTScope.h
@@ -98,7 +98,7 @@ void ext_executeCleanupBlock (__strong ext_cleanupBlock_t *block);
 #define ext_strongify_(INDEX, VAR) \
     __strong __typeof__(VAR) VAR = metamacro_concat(VAR, _weak_);
 
-// Details about the use of backing keyword:
+// Details about the choice of backing keyword:
 //
 // The use of @try/@catch/@finally can cause the compiler to suppress
 // return-type warnings.


### PR DESCRIPTION
_Depends on #67_

As discussed in the comments of #51, empty `@autoreleasepool {}` are not optimized away by clang. This change keeps the use of `@autoreleasepool` in `DEBUG` builds to avoid the suppressed warnings identified ReactiveCocoa/ReactiveCocoa#952, and uses `@try/@catch` otherwise, to avoid unnecessary autorelease pool creation.

I've run the tests in both Debug and Release configurations.

Resolves #66
