### PR TITLE
Changed backing keyword

### DIFF
--- a/extobjc/EXTScope.h
+++ b/extobjc/EXTScope.h
@@ -100,17 +100,9 @@ void ext_executeCleanupBlock (__strong ext_cleanupBlock_t *block);
 
 // Details about the choice of backing keyword:
 //
-// The use of @try/@catch/@finally can cause the compiler to suppress
-// return-type warnings.
-// The use of @autoreleasepool {} is not optimized away by the compiler,
-// resulting in superfluous creation of autorelease pools.
-//
-// Since neither option is perfect, and with no other alternatives, the
-// compromise is to use @autorelease in DEBUG builds to maintain compiler
-// analysis, and to use @try/@catch otherwise to avoid insertion of unnecessary
-// autorelease pools.
-#if DEBUG
-#define ext_keywordify autoreleasepool {}
-#else
-#define ext_keywordify try {} @catch (...) {}
-#endif
+// Use a string comparison that will (hopefully) be suppressed by the compiler.
+#define rac_keywordify \
+    _Pragma("clang diagnostic push") \
+    _Pragma("clang diagnostic ignored \"-Wunused-comparison\"") \
+    "" == nil; \
+    _Pragma("clang diagnostic pop")

--- a/extobjc/EXTScope.h
+++ b/extobjc/EXTScope.h
@@ -101,7 +101,7 @@ void ext_executeCleanupBlock (__strong ext_cleanupBlock_t *block);
 // Details about the choice of backing keyword:
 //
 // Use a string comparison that will (hopefully) be suppressed by the compiler.
-#define rac_keywordify \
+#define ext_keywordify \
     _Pragma("clang diagnostic push") \
     _Pragma("clang diagnostic ignored \"-Wunused-comparison\"") \
     "" == nil; \


### PR DESCRIPTION
Get rid of `autoreleasepool {}` and `try {} @catch (...)` in backing keyword definition.
