### PR TITLE
Add References Badge to Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Reference Status](https://www.versioneye.com/objective-c/libextobjc/reference_badge.svg?style=flat)](https://www.versioneye.com/objective-c/libextobjc/references)
+
 The Extended Objective-C library extends the dynamism of the Objective-C programming language to support additional patterns present in other programming languages (including those that are not necessarily object-oriented).
 
 libextobjc is meant to be very modular – most of its classes and modules can be used with no more than one or two dependencies.


### PR DESCRIPTION
Currently 30 projects in CocoaPods depend on libextobjc. The badge links to a page where they are all listed. Many references are a good sign for a high quality project. Keep up the good work. 
