### PR TITLE
Fix warning in ext_getPropertyAccessorsForClass

### DIFF
--- a/extobjc/EXTRuntimeExtensions.m
+++ b/extobjc/EXTRuntimeExtensions.m
@@ -707,7 +707,7 @@ BOOL ext_getPropertyAccessorsForClass (objc_property_t property, Class aClass, M
     SEL setterName = attributes->setter;
     
     free(attributes);
-    attributes = NO;
+    attributes = NULL;
 
     /*
      * set up an autorelease pool in case this sends aClass its first message


### PR DESCRIPTION
I'm getting the following warning in Xcode 6 beta 6:

> Pods/libextobjc/extobjc/EXTRuntimeExtensions.m:710:18: Initialization of pointer of type 'ext_propertyAttributes *' to null from a constant boolean expression

![screen shot 2014-08-20 at 10 39 42 am](https://cloud.githubusercontent.com/assets/442307/3985547/9d60bd9e-2892-11e4-90cb-300b0bd4d15f.png)

My understanding is limited, but it seems as though `attributes` is no longer used after the `free(attributes)` line. My changes fix the warning, but would this change have any unintended consequences? I ran the tests and they pass (though they fail to compile without the fix due to the warning).
