### PR TITLE
Fix variable name typo

### DIFF
--- a/extobjc/EXTKeyPathCoding.h
+++ b/extobjc/EXTKeyPathCoding.h
@@ -53,10 +53,10 @@ NSString *lowercaseStringPath = @keypath(NSString.new, lowercaseString);
  *
  * @code
  
- NSString *employessFirstNamePath = @collectionKeypath(department.employees, Employee.new, firstName)
+ NSString *employeesFirstNamePath = @collectionKeypath(department.employees, Employee.new, firstName)
  // => @"employees.firstName"
  
- NSString *employessFirstNamePath = @collectionKeypath(Department.new, employees, Employee.new, firstName)
+ NSString *employeesFirstNamePath = @collectionKeypath(Department.new, employees, Employee.new, firstName)
  // => @"employees.firstName"
 
  * @endcode


### PR DESCRIPTION
Just a little typo in one of the comments for `collectionKeypath`