### PR TITLE
make Xcode7.0.1 happy on OSX

### DIFF
--- a/extobjc/EXTRuntimeExtensions.h
+++ b/extobjc/EXTRuntimeExtensions.h
@@ -8,6 +8,7 @@
 //
 
 #import <objc/runtime.h>
+#import <Foundation/Foundation.h>
 
 /**
  * A callback indicating that the given method failed to be added to the given


### PR DESCRIPTION
when compile source files into my project, it warns:
libextobjc/extobjc/EXTRuntimeExtensions.h:21:61: Function definition declared 'typedef'
