### PR TITLE
Implemented self method on EXTNil

### DIFF
--- a/extobjc/EXTNil.m
+++ b/extobjc/EXTNil.m
@@ -28,6 +28,10 @@ static id singleton = nil;
     return self;
 }
 
+- (instancetype)self {
+    return nil;
+}
+
 #pragma mark NSCopying
 
 - (id)copyWithZone:(NSZone *)zone {


### PR DESCRIPTION
Just found amazing solution for this case: https://github.com/jspahrsummers/libextobjc/pull/101

Solution:
```
NSArray<UIViewController *> *horizontalViewControllers = @[
    self.trendsViewController ?: [EXTNil null],
    self.trendGroupsViewController,
    self.searchViewController,
    self.bookmarksViewController ?: [EXTNil null],
];
return [horizontalViewControllers[index] self];
```

Just to call `- (instancetype)self` selector!!! I checked who ever called this selector in iOS application. This happenes only 2!!!! times on app start for 1!!!! private UIKit class. I think we can implement this method in our class `EXTNil` like we want, nobody cares - nothing will be broken :)