### PR TITLE
Changes property attributes type from char array to pointer

### DIFF
--- a/extobjc/EXTRuntimeExtensions.h
+++ b/extobjc/EXTRuntimeExtensions.h
@@ -155,7 +155,7 @@ typedef struct {
      * The type encoding for the value of this property. This is the type as it
      * would be returned by the \c \@encode() directive.
      */
-    char type[];
+    char *type;
 } ext_propertyAttributes;
 
 /**

--- a/extobjc/EXTRuntimeExtensions.m
+++ b/extobjc/EXTRuntimeExtensions.m
@@ -463,10 +463,17 @@ ext_propertyAttributes *ext_copyPropertyAttributes (objc_property_t property) {
         return NULL;
     }
 
-    // allocate enough space for the structure and the type string (plus a NUL)
-    ext_propertyAttributes *attributes = calloc(1, sizeof(ext_propertyAttributes) + typeLength + 1);
+    // allocate enough space for the structure (plus a NUL)
+    ext_propertyAttributes *attributes = calloc(1, sizeof(ext_propertyAttributes) + 1);
     if (!attributes) {
         fprintf(stderr, "ERROR: Could not allocate ext_propertyAttributes structure for attribute string \"%s\" for property %s\n", attrString, property_getName(property));
+        return NULL;
+    }
+
+    // allocate enough space for the type string (plus a NUL)
+    attributes->type = calloc(1, typeLength + 1);
+    if (attributes->type == NULL) {
+        fprintf(stderr, "ERROR: Could not allocate property attributes type string for attribute string  \"%s\" for property %s\n", attrString, property_getName(property));
         return NULL;
     }
 


### PR DESCRIPTION
In reference to https://github.com/Mantle/MTLManagedObjectAdapter/issues/8

Also discussions in:
- https://github.com/Mantle/MTLManagedObjectAdapter/pull/21
- https://github.com/Mantle/MTLManagedObjectAdapter/pull/22

Once incorporated, this would resolve compilation issues comparing the type char array to a null pointer.

"This is a legitimate warning/error. A NULL comparison is useless because the character array is embedded in the structure allocation itself. But, ideally, this would be fixed upstream in libextobjc. -- @jspahrsummers"

I'm more than happy to incorporate any feedback prior the pull as needed.  Once executed, I'll also file additional pulls in a few of the other projects (like Mantle) to trickle this down.