### PR TITLE
Update metamacros.h

### DIFF
--- a/extobjc/metamacros.h
+++ b/extobjc/metamacros.h
@@ -44,7 +44,7 @@
  * Inspired by P99: http://p99.gforge.inria.fr
  */
 #define metamacro_argcount(...) \
-        metamacro_at(20, __VA_ARGS__, 20, 19, 18, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1)
+        metamacro_at(20, ##__VA_ARGS__, 20, 19, 18, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0)
 
 /**
  * Identical to #metamacro_foreach_cxt, except that no CONTEXT argument is


### PR DESCRIPTION
Fix metamacro_argcount macro when __VA_ARGS_'s count is 0

### Thanks for wanting to contribute to this project!
### Unfortunately, it's not really maintained anymore.

Feel free to use it as-is, or fork it and modify as much as you want to suit your needs.
However, I can't guarantee that I'll have time/energy to look at new issues and pull requests.

Sorry for the trouble!
