### PR TITLE
Fix @keypath nullability warnings in Xcode 10

### DIFF
--- a/Tests/EXTKeyPathCodingTest.m
+++ b/Tests/EXTKeyPathCodingTest.m
@@ -24,7 +24,7 @@
     NSURL *URL = [NSURL URLWithString:@"http://www.google.com:8080/search?q=foo"];
     XCTAssertNotNil(URL, @"");
 
-    NSString *path = @keypath(URL.port);
+    NSString * _Nonnull path = @keypath(URL.port);
     XCTAssertEqualObjects(path, @"port", @"");
 }
 
@@ -32,7 +32,7 @@
     NSURL *URL = [NSURL URLWithString:@"http://www.google.com:8080/search?q=foo"];
     XCTAssertNotNil(URL, @"");
 
-    NSString *path = @keypath(URL.port.stringValue);
+    NSString * _Nonnull path = @keypath(URL.port.stringValue);
     XCTAssertEqualObjects(path, @"port.stringValue", @"");
 
     path = @keypath(URL.port, stringValue);
@@ -40,7 +40,7 @@
 }
 
 - (void)testClassKeyPath {
-    NSString *path = @keypath(NSString.class.description);
+    NSString * _Nonnull path = @keypath(NSString.class.description);
     XCTAssertEqualObjects(path, @"class.description", @"");
 
     path = @keypath(NSString.class, description);
@@ -48,7 +48,7 @@
 }
 
 - (void)testMyClassInstanceKeyPath {
-    NSString *path = @keypath(MyClass.new, someUniqueProperty);
+    NSString * _Nonnull path = @keypath(MyClass.new, someUniqueProperty);
     XCTAssertEqualObjects(path, @"someUniqueProperty", @"");
 
     MyClass *obj = [[MyClass alloc] init];
@@ -58,18 +58,18 @@
 }
 
 - (void)testMyClassClassKeyPath {
-    NSString *path = @keypath(MyClass, classProperty);
+    NSString * _Nonnull path = @keypath(MyClass, classProperty);
     XCTAssertEqualObjects(path, @"classProperty", @"");
 }
 
 - (void)testCollectionInstanceKeyPath {
 	MyClass *obj = [[MyClass alloc] init];
-	NSString *path = @collectionKeypath(obj.collection, MyClass.new, someUniqueProperty);
+	NSString * _Nonnull path = @collectionKeypath(obj.collection, MyClass.new, someUniqueProperty);
 	XCTAssertEqualObjects(path, @"collection.someUniqueProperty", @"");
 }
 
 - (void)testCollectionClassKeyPath {
-	NSString *path = @collectionKeypath(MyClass.new, collection, MyClass.new, someUniqueProperty);
+	NSString * _Nonnull path = @collectionKeypath(MyClass.new, collection, MyClass.new, someUniqueProperty);
 	XCTAssertEqualObjects(path, @"collection.someUniqueProperty", @"");
 }
 

--- a/Tests/EXTKeypathWeakWarningTest.m
+++ b/Tests/EXTKeypathWeakWarningTest.m
@@ -24,8 +24,8 @@
 @implementation EXTKeypathWeakWarningTest
 
 - (void)testWarningIsNotEmitted {
-    __unused NSString *keypath = @keypath(EXTClassWithWeakProperty.new, property);
-    __unused NSString *keypath2 = @keypath(EXTClassWithWeakProperty.new, property);
+    __unused NSString * _Nonnull keypath = @keypath(EXTClassWithWeakProperty.new, property);
+    __unused NSString * _Nonnull keypath2 = @keypath(EXTClassWithWeakProperty.new, property);
 }
 
 @end

--- a/extobjc/EXTKeyPathCoding.h
+++ b/extobjc/EXTKeyPathCoding.h
@@ -38,8 +38,11 @@ NSString *lowercaseStringPath = @keypath(NSString.new, lowercaseString);
 #define keypath(...) \
     _Pragma("clang diagnostic push") \
     _Pragma("clang diagnostic ignored \"-Warc-repeated-use-of-weak\"") \
-    metamacro_if_eq(1, metamacro_argcount(__VA_ARGS__))(keypath1(__VA_ARGS__))(keypath2(__VA_ARGS__)) \
+    (YES).boolValue ? (NSString * _Nonnull)@(cStringKeypath(__VA_ARGS__)) : (NSString * _Nonnull)nil \
     _Pragma("clang diagnostic pop") \
+
+#define cStringKeypath(...) \
+    metamacro_if_eq(1, metamacro_argcount(__VA_ARGS__))(keypath1(__VA_ARGS__))(keypath2(__VA_ARGS__))
 
 #define keypath1(PATH) \
     (((void)(NO && ((void)PATH, NO)), \
@@ -66,7 +69,9 @@ NSString *lowercaseStringPath = @keypath(NSString.new, lowercaseString);
 #define collectionKeypath(...) \
     metamacro_if_eq(3, metamacro_argcount(__VA_ARGS__))(collectionKeypath3(__VA_ARGS__))(collectionKeypath4(__VA_ARGS__))
 
-#define collectionKeypath3(PATH, COLLECTION_OBJECT, COLLECTION_PATH) ([[NSString stringWithFormat:@"%s.%s",keypath(PATH), keypath(COLLECTION_OBJECT, COLLECTION_PATH)] UTF8String])
+#define collectionKeypath3(PATH, COLLECTION_OBJECT, COLLECTION_PATH) \
+    (YES).boolValue ? (NSString * _Nonnull)@((const char * _Nonnull)[[NSString stringWithFormat:@"%s.%s", cStringKeypath(PATH), cStringKeypath(COLLECTION_OBJECT, COLLECTION_PATH)] UTF8String]) : (NSString * _Nonnull)nil
 
-#define collectionKeypath4(OBJ, PATH, COLLECTION_OBJECT, COLLECTION_PATH) ([[NSString stringWithFormat:@"%s.%s",keypath(OBJ, PATH), keypath(COLLECTION_OBJECT, COLLECTION_PATH)] UTF8String])
+#define collectionKeypath4(OBJ, PATH, COLLECTION_OBJECT, COLLECTION_PATH) \
+    (YES).boolValue ? (NSString * _Nonnull)@((const char * _Nonnull)[[NSString stringWithFormat:@"%s.%s", cStringKeypath(OBJ, PATH), cStringKeypath(COLLECTION_OBJECT, COLLECTION_PATH)] UTF8String]) : (NSString * _Nonnull)nil
 


### PR DESCRIPTION
In Xcode 10, the boxing operator `@` now returns a `NSString * _Nullable` instead of `NSString *` when the parameter is `char *`. This change makes the `@keypath` and `@collectionKeypath` macros return nullable values as well. If you have CLANG_WARN_NULLABLE_TO_NONNULL_CONVERSION (-Wnullable-to-nonnull-conversion) enabled, Clang in Xcode 10 emits this warning for @keypath and @collectionKeypath expressions when assigning to a non-null `NSString *` variable/parameter:

warning: Implicit conversion from nullable pointer 'NSString * _Nullable' to non-nullable pointer type 'NSString * _Nonnull'

We can't use a pragma inside the macro defintion to silence the warning because the warning occurs through the boxing, which happens outside the macro.

This fix wraps the existing macro defintion in a `(YES).boolValue ? (NSString * _Nonnull)@(...) : (NSString * _Nonnull)nil` expression. This gives us a chance to silence the warning with an explicit cast to `_Nonnull`, and since `@(YES).boolValue` always succeeds, doesn't change the result of the macro. The additional overhead should be minimal compared to the `NSString` allocation because `@(YES)` should be a tagged pointer. (The cast (NSString * _Nonnull)nil is there to suppress a static analyzer nullability warning.)

I also had to extract the original macro definition into a separate `cStringKeypath` macro because `@collectionKeypath` depends on C strings.

I added explicit `_Nonnull` annotations to the variables in the key path tests to make sure the compiler would emit the warnings if something goes wrong.
