### PR TITLE
Make @keypath macro more resilient when combined with other expressions

### DIFF
--- a/extobjc/EXTKeyPathCoding.h
+++ b/extobjc/EXTKeyPathCoding.h
@@ -38,7 +38,7 @@ NSString *lowercaseStringPath = @keypath(NSString.new, lowercaseString);
 #define keypath(...) \
     _Pragma("clang diagnostic push") \
     _Pragma("clang diagnostic ignored \"-Warc-repeated-use-of-weak\"") \
-    (YES).boolValue ? (NSString * _Nonnull)@(cStringKeypath(__VA_ARGS__)) : (NSString * _Nonnull)nil \
+    (NO).boolValue ? ((NSString * _Nonnull)nil) : ((NSString * _Nonnull)@(cStringKeypath(__VA_ARGS__))) \
     _Pragma("clang diagnostic pop") \
 
 #define cStringKeypath(...) \


### PR DESCRIPTION
The nullability warnings fix for the `@keypath` macro introduced in #134 makes the macro more likely to break when used in larger expressions because we can't wrap the entire macro in parentheses anymore. This commit improves the situation a little. By reversing the condition of the ternary operator, the significant branch now stands at the end of the macro. This means that continuations of the form `@keypath(...).someProperty` have a bigger chance of doing the right thing.

Admittedly, the macro is still more brittle than before the nullability fix. If a `@keypath` usage in your code behaves weirdly, try wrapping it in parentheses.

Thanks to @barakwei for suggesting this change (https://github.com/Lightricks/libextobjc/pull/10#issuecomment-400949940).
