### PR TITLE
Update EXTKeyPathCoding.h

### DIFF
--- a/extobjc/EXTKeyPathCoding.h
+++ b/extobjc/EXTKeyPathCoding.h
@@ -49,7 +49,7 @@ NSString *lowercaseStringPath = @keypath(NSString.new, lowercaseString);
     ({ char *__extobjckeypath__ = strchr(# PATH, '.'); NSCAssert(__extobjckeypath__, @"Provided key path is invalid."); __extobjckeypath__ + 1; })))
 
 #define keypath2(OBJ, PATH) \
-    (((void)(NO && ((void)OBJ.PATH, NO)), # PATH))
+    (((void)(NO && ((void)(((typeof(OBJ))nil).PATH), NO)), # PATH))
 
 /**
  * \@collectionKeypath allows compile-time verification of key paths across collections NSArray/NSSet etc. Given a real object


### PR DESCRIPTION
To support the following form of usage: (`str` is a instance of `NSString *`)
* `@keypath(str, lowercaseString.UTF8String)`
* `@keypath(NSString *, lowercaseString.UTF8String)`
* `@keypath(NSString.new, lowercaseString.UTF8String)`

