### PR TITLE
Fix a crash in ext_globalMethodSignatureForSelector

### DIFF
--- a/extobjc/EXTRuntimeExtensions.m
+++ b/extobjc/EXTRuntimeExtensions.m
@@ -774,8 +774,11 @@ NSMethodSignature *ext_globalMethodSignatureForSelector (SEL aSelector) {
                     method = class_getClassMethod(cls, aSelector);
 
                 if (method) {
-                    methodDesc = (ext_methodDescription){.name = aSelector, .types = method_getTypeEncoding(method)};
-                    break;
+                    const char *types = method_getTypeEncoding(method);
+                    if (types && strlen(types) > 0) {
+                        methodDesc = (ext_methodDescription){.name = aSelector, .types = types};
+                        break;
+                    }
                 }
             }
         }

--- a/libextobjc.podspec.json
+++ b/libextobjc.podspec.json
@@ -1,21 +1,18 @@
 {
   "name": "libextobjc",
-  "version": "0.6",
+  "version": "0.6.0.1",
   "summary": "A Cocoa library to extend the Objective-C programming language.",
   "homepage": "https://github.com/jspahrsummers/libextobjc",
   "authors": {
     "Justin Spahr-Summers": "jspahrsummers@github.com"
   },
   "source": {
-    "git": "https://github.com/jspahrsummers/libextobjc.git",
-    "tag": "0.6"
+    "git": "https://github.com/allenhsu/libextobjc.git",
+    "tag": "0.6.0.1"
   },
   "requires_arc": true,
-  "description": "                    The Extended Objective-C library extends the dynamism of the Objective-C programming language to support additional patterns present in other dynamic programming languages (including those that are not necessarily object-oriented).\n\n                    libextobjc is meant to be very modular – most of its classes and modules can be used with no more than one or two dependencies.                    \n",
-  "license": {
-    "type": "MIT",
-    "text": "                      Copyright (c) 2012 Justin Spahr-Summers\n\n                      Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the \"Software\"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:\n\n                      The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.\n\n                      THE SOFTWARE IS PROVIDED \"AS IS\", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.\n"
-  },
+  "description": "The Extended Objective-C library extends the dynamism of the Objective-C programming language to support additional patterns present in other dynamic programming languages (including those that are not necessarily object-oriented).\nlibextobjc is meant to be very modular – most of its classes and modules can be used with no more than one or two dependencies.",
+  "license": "MIT",
   "subspecs": [
     {
       "name": "UmbrellaHeader",


### PR DESCRIPTION
I'm not sure if it's iOS 12 related, but I encountered this crash when building with Xcode 10, iOS 12 SDK.

I'm using `EXTNil` to safely insert nil into `NSDictionary`, which worked like a charm before. With iOS 12, I encountered a crash from `EXTNil`. After tracing the stack, I noticed in `ext_globalMethodSignatureForSelector`, line 777, `method_getTypeEncoding` returns an empty c string for some selectors, which is `longLongValue` in my case.

I added a check for return value of method_getTypeEncoding, it works fine now.