### PR TITLE
Ensure property attributes don't leak

### DIFF
--- a/extobjc/EXTRuntimeExtensions.m
+++ b/extobjc/EXTRuntimeExtensions.m
@@ -483,7 +483,7 @@ ext_propertyAttributes *ext_copyPropertyAttributes (objc_property_t property) {
 
         if (!next) {
             fprintf(stderr, "ERROR: Could not read class name in attribute string \"%s\" for property %s\n", attrString, property_getName(property));
-            return NULL;
+            goto errorOut;
         }
 
         if (className != next) {


### PR DESCRIPTION
As reported by the analyzer, there is a "potential leak of memory pointed to by 'attributes'". Taking a closer look, this seems to be true and actually is take care of [in another case]( https://github.com/felixjendrusch/libextobjc/blob/31927ddccd68564addcf310741b0c252225ddcea/extobjc/EXTRuntimeExtensions.m#L486).