### PR TITLE
Add minimum OS versions to stop warnings

### DIFF
--- a/libextobjc.podspec.json
+++ b/libextobjc.podspec.json
@@ -16,6 +16,12 @@
     "type": "MIT",
     "text": "                      Copyright (c) 2012 Justin Spahr-Summers\n\n                      Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the \"Software\"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:\n\n                      The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.\n\n                      THE SOFTWARE IS PROVIDED \"AS IS\", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.\n"
   },
+  "platforms": {
+    "osx": "10.12",
+    "ios": "10.0",
+    "tvos": "10.0",
+    "watchos": "3.0"
+  },
   "subspecs": [
     {
       "name": "UmbrellaHeader",


### PR DESCRIPTION
- with a podspec.json if a platform version isn’t defined, the lowest version available will be used.
- ’os_unfair_lock_trylock' is only available on iOS 10.0, macOS 10.12, tvOS 10.0 and watchOS 3.0 or newer
- [see Apple Docs](https://developer.apple.com/documentation/os/1646469-os_unfair_lock_trylock)

### Thanks for wanting to contribute to this project!
### Unfortunately, it's not really maintained anymore.

Feel free to use it as-is, or fork it and modify as much as you want to suit your needs.
However, I can't guarantee that I'll have time/energy to look at new issues and pull requests.

Sorry for the trouble!
